### PR TITLE
Support For ES6 Classes

### DIFF
--- a/src_es6/dist/reactalike.js
+++ b/src_es6/dist/reactalike.js
@@ -265,7 +265,6 @@ function flattenIteration(arr, flatArr) {
 module.exports = {
    smoothArray: function smoothArray() {
       return function (nested) {
-         // if( Array.isArray(nested) ) return [];
 
          return nested.reduce(_flatten, []).filter(function (ne) {
             return ne !== null && ne !== undefined;
@@ -555,6 +554,10 @@ NodeMap.prototype.component = function (obj) {
    }
 };
 
+NodeMap.prototype.Component = function Component(props) {
+   this.props = props;
+};
+
 NodeMap.prototype.node = function (type) {
    for (var _len = arguments.length, nested = Array(_len > 2 ? _len - 2 : 0), _key = 2; _key < _len; _key++) {
       nested[_key - 2] = arguments[_key];
@@ -562,9 +565,15 @@ NodeMap.prototype.node = function (type) {
 
    var props = arguments.length > 1 && arguments[1] !== undefined ? arguments[1] : {};
 
+   console.log('EX.node', type);
+
    if (typeof type === "function") {
+      if (type.__proto__.name === 'Component') {
+         return new type(props).render();
+      }
       return type(props);
    }
+
    if (nested) {
       nested = smoothNested(nested);
    } else {

--- a/src_es6/ex.js
+++ b/src_es6/ex.js
@@ -252,10 +252,20 @@ NodeMap.prototype.component = (obj) => {
    }
 };
 
+NodeMap.prototype.Component = function Component(props) {
+    this.props = props;
+}
+
 NodeMap.prototype.node = (type, props = {}, ...nested) => {
+   console.log('EX.node', type)
+
    if (typeof type === "function") {
+      if (type.__proto__.name === 'Component') {
+        return new type(props).render()
+      }
       return type(props);
    }
+
    if (nested) {
       nested = smoothNested(nested);
    } else {


### PR DESCRIPTION
Just for sake of documentation, I added in support for defining components as classes similar to React. 

### new feature: creating a es6 class: 

```javascript
class ListItem extends EX.Component {
  render() {
    let { ex_text, ex_class} = this.props
    return(
        <li class={ex_class}>{ex_text}</li>
    )
  }
}
```

### Things To Note:

- Right now the way props are passed between the two different methods for creating components are the same.

