### PR TITLE
Modifications to make DOM mounting more declarative/simplified

### DIFF
--- a/src_es6/dist/reactalike.js
+++ b/src_es6/dist/reactalike.js
@@ -424,11 +424,12 @@ function NodeMap() {
       NodeMapContext.mountedCallbacks = [];
    };
 
-   this.createComponent = function (obj, containerElement) {
-
+   this.mountToNode = function (AppContainer, containerElement) {
+      NodeMapContext.rootComponent = AppContainer;
       if (NodeMapContext.getElement(containerElement)) {
-         obj.domElement = NodeMapContext.appRoot;
-         NodeMapContext.mountApp(obj);
+         var appRender = AppContainer.render();
+         appRender.domElement = NodeMapContext.appRoot;
+         NodeMapContext.mountApp(appRender);
       };
    };
 

--- a/src_es6/dist/reactalike.js
+++ b/src_es6/dist/reactalike.js
@@ -424,7 +424,7 @@ function NodeMap() {
       NodeMapContext.mountedCallbacks = [];
    };
 
-   this.mountToNode = function (AppContainer, containerElement) {
+   this.mountAppToNode = function (AppContainer, containerElement) {
       NodeMapContext.rootComponent = AppContainer;
       if (NodeMapContext.getElement(containerElement)) {
          var appRender = AppContainer.render();

--- a/src_es6/ex.js
+++ b/src_es6/ex.js
@@ -118,11 +118,12 @@ function NodeMap(appTitle = 'default') {
       NodeMapContext.mountedCallbacks = [];
    };
 
-   this.createComponent = (obj, containerElement) => {
-
+   this.mountToNode = (AppContainer, containerElement) => {
+      NodeMapContext.rootComponent = AppContainer;
       if (NodeMapContext.getElement(containerElement)) {
-         obj.domElement = NodeMapContext.appRoot;
-         NodeMapContext.mountApp(obj);
+         const appRender = AppContainer.render()
+         appRender.domElement = NodeMapContext.appRoot;
+         NodeMapContext.mountApp(appRender);
       };
    };
 

--- a/src_es6/ex.js
+++ b/src_es6/ex.js
@@ -118,7 +118,7 @@ function NodeMap(appTitle = 'default') {
       NodeMapContext.mountedCallbacks = [];
    };
 
-   this.mountToNode = (AppContainer, containerElement) => {
+   this.mountAppToNode = (AppContainer, containerElement) => {
       NodeMapContext.rootComponent = AppContainer;
       if (NodeMapContext.getElement(containerElement)) {
          const appRender = AppContainer.render()


### PR DESCRIPTION
**Note:** I created this Pull Request just for sake of documentation, since this is a personal project. 

### Changes: Declarative Mounting 
I realized that mounting an app to an HTML element required lots of random steps that could easily be abstracted into the mounting method itself.  

**Before:** Mounting an app
```javascript
import EX from 'reactalike'
import Layout from 'container/layout' 

EX.rootComponent = Layout

EX.createComponent(
  Layout.render() , document.getElementById('root'));
```

**After:** Mounting an app
```javascript
import EX from 'reactalike'
import Layout from 'container/layout' 

EX.mountAppToNode(
  Layout, document.getElementById('root'));
```