### PR TITLE
Move SetState Lifecycle Method Into mountAppToNode

### DIFF
--- a/src_es6/dist/reactalike.js
+++ b/src_es6/dist/reactalike.js
@@ -426,6 +426,14 @@ function NodeMap() {
 
    this.mountAppToNode = function (AppContainer, containerElement) {
       NodeMapContext.rootComponent = AppContainer;
+      AppContainer.state = AppContainer.state ? AppContainer.state : {};
+      NodeMapContext.SetState = function () {
+         return function (payload) {
+            AppContainer.state = Object.assign({}, AppContainer.state, payload);
+            NodeMapContext.objectChange(AppContainer.render());
+         };
+      }();
+
       if (NodeMapContext.getElement(containerElement)) {
          var appRender = AppContainer.render();
          appRender.domElement = NodeMapContext.appRoot;
@@ -533,10 +541,6 @@ function NodeMap() {
    this.updateElement = function (oldNode, newNode) {
       NodeMapContext.diffElements(NodeMapContext.appRootDom, newNode, oldNode);
       NodeMapContext.domComponents = Object.assign({}, oldNode, newNode);
-   };
-
-   this.SetState = function (data) {
-      console.log('not yet set');
    };
 };
 

--- a/src_es6/ex.js
+++ b/src_es6/ex.js
@@ -120,6 +120,14 @@ function NodeMap(appTitle = 'default') {
 
    this.mountAppToNode = (AppContainer, containerElement) => {
       NodeMapContext.rootComponent = AppContainer;
+      AppContainer.state = AppContainer.state ? AppContainer.state : {};
+      NodeMapContext.SetState = (() => {
+        return (payload) => {
+          AppContainer.state = Object.assign({}, AppContainer.state, payload);
+          NodeMapContext.objectChange(AppContainer.render());
+        }
+      })()
+
       if (NodeMapContext.getElement(containerElement)) {
          const appRender = AppContainer.render()
          appRender.domElement = NodeMapContext.appRoot;
@@ -230,10 +238,6 @@ function NodeMap(appTitle = 'default') {
    this.updateElement = (oldNode, newNode) => {
       NodeMapContext.diffElements(NodeMapContext.appRootDom, newNode, oldNode);
       NodeMapContext.domComponents = Object.assign({}, oldNode, newNode);
-   }
-
-   this.SetState = (data) => {
-      console.log('not yet set');
    }
 
 };


### PR DESCRIPTION
**Note:** I created this Pull Request just for sake of documentation, since this is a personal project. 

### Changes: SetState Auto Wrapping
Not sure why I did not do this earlier, but I moved the `SetState` Lifecycle method into `mountAppToNode`. Right now this only happens on the root container, although I could eventually add this to individual components, but right now I feel it's best to limit state to the parent container(Redux style).  

**Before:** Manually setting up the Lifecycle method :disappointed:
```javascript
import EX from 'reactalike'
import Layout from 'container/layout' 

EX.SetState = (() => {
  return (payload) => {
    Layout.state = Object.assign({}, Layout.state, payload);
    EX.objectChange(Layout.render());
  }
})();

EX.mountAppToNode(
  Layout, document.getElementById('root'));
```

**After:** The same only without declaring `SetState`
```javascript
import EX from 'reactalike'
import Layout from 'container/layout' 

EX.mountAppToNode(
  Layout, document.getElementById('root'));
```